### PR TITLE
feat: issueから技術ブログを更新できるようにする

### DIFF
--- a/.github/ISSUE_TEMPLATE/learning.yml
+++ b/.github/ISSUE_TEMPLATE/learning.yml
@@ -1,0 +1,55 @@
+name: 学びメモ
+description: 技術的な学びを記録する
+labels: ["learning"]
+body:
+  - type: input
+    id: title
+    attributes:
+      label: タイトル（Issue タイトルに入力してください）
+      description: "例: React Hooks の基礎"
+    validations:
+      required: false
+
+  - type: textarea
+    id: mechanism
+    attributes:
+      label: どんな技術でどういう仕組み？
+      placeholder: |
+        例: React Hooks は関数コンポーネントで state やライフサイクルを扱うための仕組み。
+        useState が内部的にレンダリングサイクルに紐づいた配列に状態を保持している。
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 何を解決できる？
+      placeholder: |
+        例: クラスコンポーネントを使わずに state 管理ができる。
+        コードが短くなりロジックを関数として再利用しやすくなる。
+    validations:
+      required: true
+
+  - type: textarea
+    id: best_practices
+    attributes:
+      label: ベストプラクティス
+      placeholder: |
+        - useEffect の依存配列は省略しない
+        - カスタム Hooks でロジックを分離する
+    validations:
+      required: false
+
+  - type: textarea
+    id: code_example
+    attributes:
+      label: コードを書くとどうなる？
+      render: tsx
+      placeholder: |
+        const [count, setCount] = useState(0);
+
+        useEffect(() => {
+          document.title = `count: ${count}`;
+        }, [count]);
+    validations:
+      required: false

--- a/.github/scripts/create_learning_post.py
+++ b/.github/scripts/create_learning_post.py
@@ -1,0 +1,35 @@
+import os
+import re
+from datetime import datetime, timezone
+
+title = os.environ.get("ISSUE_TITLE", "untitled")
+body = os.environ.get("ISSUE_BODY", "")
+issue_number = os.environ.get("ISSUE_NUMBER", "0")
+created_at = os.environ.get("ISSUE_CREATED_AT", datetime.now(timezone.utc).isoformat())
+
+date_str = created_at[:10]
+
+# ASCII-only slug from title + issue number for uniqueness
+ascii_part = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+slug = f"{ascii_part}-{issue_number}" if ascii_part else f"issue-{issue_number}"
+
+filename = f"_learning/{date_str}-{slug}.md"
+
+# Escape double quotes in title for YAML
+title_escaped = title.replace('"', '\\"')
+
+content = f"""---
+title: "{title_escaped}"
+date: {date_str}
+issue: {issue_number}
+---
+
+{body}
+"""
+
+os.makedirs("_learning", exist_ok=True)
+
+with open(filename, "w", encoding="utf-8") as f:
+    f.write(content)
+
+print(f"Created: {filename}")

--- a/.github/workflows/learning-post.yml
+++ b/.github/workflows/learning-post.yml
@@ -1,0 +1,46 @@
+name: Create Learning Post from Issue
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  create-post:
+    if: github.event.label.name == 'learning'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create learning post
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_CREATED_AT: ${{ github.event.issue.created_at }}
+        run: python3 .github/scripts/create_learning_post.py
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add _learning/
+          git diff --staged --quiet || git commit -m "add: learning - ${{ github.event.issue.title }}"
+          git push
+
+      - name: Comment on issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '✅ 学びエントリを作成しました。GitHub Pages のビルド完了後に公開されます（通常1〜2分）。'
+            })

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ description: "開発経歴や自分がどんな業務をやってきたかを残
 url: "https://kazukikanomata.github.io"
 baseurl: ""
 
+github_username: kazukikanomata
+github_repo: kazukikanomata.github.io
+
 
 # Favicon
 favicon: /assets/images/favicon.png
@@ -26,10 +29,21 @@ navigation:
     url: /about
   - text: Work
     url: /work
-  - text: Showcase
-    url: /showcase
-  - text: Themes
-    url: /themes
+  - text: Learning
+    url: /learning
+
+# Collections
+collections:
+  learning:
+    output: true
+    permalink: /learning/:name/
+
+defaults:
+  - scope:
+      path: ""
+      type: "learning"
+    values:
+      layout: "learning"
 
 # The shortname for your Disqus site to enable comments.
 disqus: justgoodthemes

--- a/_layouts/learning.html
+++ b/_layouts/learning.html
@@ -1,0 +1,23 @@
+---
+layout: default
+---
+
+<main class="main-content fadeInDown delay_075s">
+  <article class="post">
+    <header class="post-header">
+      <time class="post-date" datetime="{{ page.date | date: "%Y-%m-%d" }}">{{ page.date | date: "%Y-%m-%d" }}</time>
+      <h1 class="post-title">{{ page.title }}</h1>
+      <div class="post-meta">
+        <a href="{{ site.baseurl }}/learning">&larr; Learning 一覧</a>
+      </div>
+    </header>
+    <div class="post-content">
+      {{ content }}
+    </div>
+    {% if page.issue %}
+    <div class="post-meta" style="margin-top: 2rem; font-size: 0.85em;">
+      <a href="https://github.com/{{ site.github_username }}/{{ site.github_repo }}/issues/{{ page.issue }}" target="_blank" rel="noopener">GitHub Issue #{{ page.issue }}</a>
+    </div>
+    {% endif %}
+  </article>
+</main>

--- a/learning.md
+++ b/learning.md
@@ -1,0 +1,19 @@
+---
+layout: page
+title: Learning
+---
+
+技術的な学びを記録するページです。
+
+{% assign sorted = site.learning | sort: 'date' | reverse %}
+{% for entry in sorted %}
+
+<div style="margin-bottom: 1.5rem; padding-bottom: 1.5rem; border-bottom: 1px solid #eee;">
+  <time style="font-size: 0.85em; color: #999;">{{ entry.date | date: "%Y-%m-%d" }}</time>
+  <h2 style="margin: 0.25rem 0; font-size: 1.1rem;"><a href="{{ site.baseurl }}{{ entry.url }}">{{ entry.title }}</a></h2>
+</div>
+{% endfor %}
+
+{% if site.learning.size == 0 %}
+まだエントリがありません。
+{% endif %}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a GitHub Actions workflow that writes to the repo and auto-commits content based on issue data, which can impact repo history and publishing if mis-triggered or malformed input is posted.
> 
> **Overview**
> Adds an end-to-end *“Learning”* flow where labeling a GitHub Issue with `learning` auto-generates a Jekyll entry under `_learning/`, commits it back to the repo, and comments on the issue when done.
> 
> Introduces a new Jekyll `learning` collection and navigation entry (`/learning`), plus a dedicated `learning` post layout that links back to the originating GitHub issue. Also adds an issue template (`学びメモ`) to standardize the content captured in the issue body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8c932d441cf32f807f3f5d83ec3b761987d2c9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->